### PR TITLE
Flattened localeData to match existing pattern

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@verdocs/js-sdk",
-  "version": "6.9.12",
+  "version": "6.9.13",
   "private": false,
   "homepage": "https://github.com/Verdocs/js-sdk",
   "description": "Isomorphic JS/TS SDK providing types and API wrappers for the Verdocs platform for Node and browser clients",

--- a/src/BaseTypes.ts
+++ b/src/BaseTypes.ts
@@ -202,8 +202,3 @@ export type TEventName =
   | 'recipient:question'
   | 'delegate:requested'
   | 'delegate:send_confirmed';
-
-export interface ILocaleData {
-  locale?: string;
-  timezone?: string;
-}

--- a/src/Envelopes/Envelopes.ts
+++ b/src/Envelopes/Envelopes.ts
@@ -55,7 +55,8 @@ import {TCreateEnvelopeRequest} from './Types';
  * @apiBody integer(min: 0) followup_reminders? Override the template initial-reminder setting in ms.
  * @apiBody number max_reminder_days? Maximum number of days (after envelope creation) for which reminders will be sent. Defaults to 14.
  * @apiBody string expires_at? If set, the envelope will automatically expire (be canceled) at this date and time. Expirations must be at least 1 day in the future.
- * @apiBody ILocaleData localeData? The locale and timezone codes, as provided by the client browser.
+ * @apiBody string timezone? Define the long-form timezone.
+ * @apiBody string locale? Define the locale code.
  * @apiSuccess IEnvelope . The newly-created envelope.
  */
 export const createEnvelope = async (endpoint: VerdocsEndpoint, request: TCreateEnvelopeRequest) =>

--- a/src/Envelopes/Recipients.ts
+++ b/src/Envelopes/Recipients.ts
@@ -10,7 +10,8 @@ import type {IRecipient} from '../Models';
  * @api POST /envelopes/:envelope_id/recipients/:role_name/agree Agree to e-Signing Disclosures
  * @apiParam string(format:uuid) envelope_id The envelope to operate on.
  * @apiParam string role_name The role to operate on.
- * @apiBody ILocaleData localeData? The locale and timezone codes, as provided by the client browser.
+ * @apiBody string timezone? Define the long-form timezone.
+ * @apiBody string locale? Define the locale code.
  * @apiSuccess IRecipient . The updated Recipient.
  */
 export const envelopeRecipientAgree = (
@@ -47,7 +48,8 @@ export const envelopeRecipientDecline = (endpoint: VerdocsEndpoint, envelopeId: 
  * @api POST /envelopes/:envelope_id/recipients/:role_name/submit Submit envelope
  * @apiParam string(format:uuid) envelope_id The envelope to operate on.
  * @apiParam string role_name The role to submit.
- * @apiBody ILocaleData localeData? The locale and timezone codes, as provided by the client browser.
+ * @apiBody string timezone? Define the long-form timezone.
+ * @apiBody string locale? Define the locale code.
  * @apiSuccess IRecipient . The updated Recipient.
  */
 export const envelopeRecipientSubmit = (endpoint: VerdocsEndpoint, envelopeId: string, roleName: string, data?: IRecipientSubmitBody) =>

--- a/src/Envelopes/Types.ts
+++ b/src/Envelopes/Types.ts
@@ -1,4 +1,4 @@
-import type {ILocaleData, TEnvelopeStatus, TFieldType, TRecipientAuthMethod, TRecipientStatus, TRecipientType} from '../BaseTypes';
+import type {TEnvelopeStatus, TFieldType, TRecipientAuthMethod, TRecipientStatus, TRecipientType} from '../BaseTypes';
 import type {IDropdownOption, IEnvelope, IInitial, IRecipient, ISignature, TAccessKey} from '../Models';
 
 export interface IEnvelopesSearchResult {
@@ -143,11 +143,13 @@ export interface ICreateEnvelopeRecipientDirectly {
   ssn_last_4?: string;
 }
 export interface IRecipientDisclosureAgreeBody {
-  localeData?: ILocaleData;
+  locale?: string | null;
+  timezone?: string | null;
 }
 
 export interface IRecipientSubmitBody {
-  localeData?: ILocaleData;
+  locale?: string | null;
+  timezone?: string | null;
 }
 
 export interface ISignerTokenResponse {
@@ -372,8 +374,10 @@ export interface ICreateEnvelopeFromTemplateRequest {
   data?: any;
   /** Fields to create in the envelope. Note that document_id is a number in this call and should match the index of the document in the documents array. */
   fields?: ICreateEnvelopeFieldFromTemplate;
-  /** The locale and timezone codes, as determined by the client browser. */
-  localeData?: ILocaleData;
+  /** The long-form timezone. */
+  locale?: string | null;
+  /** The locale code */
+  timezone?: string | null;
 }
 
 export interface ICreateEnvelopeDirectlyRequest {
@@ -407,8 +411,10 @@ export interface ICreateEnvelopeDirectlyRequest {
   documents: (ICreateEnvelopeDocumentFromData | ICreateEnvelopeDocumentFromUri | ICreateEnvelopeDocumentFromFile)[];
   /** Fields to create in the envelope. Note that document_id is a number in this call and should match the index of the document in the documents array. */
   fields: ICreateEnvelopeFieldDirectly[];
-  /** The locale and timezone codes, as determined by the client browser. */
-  localeData?: ILocaleData;
+  /** The long-form timezone. */
+  locale?: string | null;
+  /** The locale code */
+  timezone?: string | null;
 }
 
 export type TCreateEnvelopeRequest = ICreateEnvelopeFromTemplateRequest | ICreateEnvelopeDirectlyRequest;

--- a/src/Models.ts
+++ b/src/Models.ts
@@ -160,8 +160,10 @@ export interface IOrganization {
   powered_by_url?: string | null;
   data?: Record<string, any> | null;
   default_brand_id?: string | null;
-  timezone: string | null;
-  locale: string | null;
+  /** The long-form timezone. */
+  locale?: string | null;
+  /** The locale code */
+  timezone?: string | null;
   /** If set, the organization may not be deleted. Must be set to false before calling DELETE. Defaults to true (protected). */
   deletion_protected: boolean;
   created_at: string;
@@ -229,8 +231,10 @@ export interface IBrand {
   email_dkim_verified: boolean;
   email_dmarc_verified: boolean;
   email_dkim_tokens: string[];
-  timezone: string | null;
-  locale: string | null;
+  /** The long-form timezone. */
+  locale?: string | null;
+  /** The locale code */
+  timezone?: string | null;
   created_at: string;
   updated_at: string;
   organization?: IOrganization;
@@ -285,8 +289,10 @@ export interface IProfile {
   current: boolean;
   permissions: TPermission[];
   roles: TRole[];
-  timezone: string | null;
-  locale: string | null;
+  /** The long-form timezone. */
+  locale?: string | null;
+  /** The locale code */
+  timezone?: string | null;
   // Creation date/time.
   created_at: string;
   // Last-update date/time.
@@ -329,8 +335,10 @@ export interface IUser {
   lock_reason?: string | null;
   /** Consecutive failed sign-in attempts. Only visible to admins or owners. */
   login_failures?: number;
-  timezone: string | null;
-  locale: string | null;
+  /** The long-form timezone. */
+  locale?: string | null;
+  /** The locale code */
+  timezone?: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -704,8 +712,10 @@ export interface IRecipient {
   created_at: string;
   updated_at: string;
   last_attempt_at?: string;
-  timezone: string | null;
-  locale: string | null;
+  /** The long-form timezone. */
+  locale?: string | null;
+  /** The locale code */
+  timezone?: string | null;
   /**
    * Only returned in creation/getEnvelopeById requests by the creator. May be used for in-person signing. Note that
    * signing sessions started with this key will be marked as "In App" authenticated. For higher authentication levels,

--- a/src/Organizations/Brands.ts
+++ b/src/Organizations/Brands.ts
@@ -20,7 +20,8 @@ export const getBrands = (endpoint: VerdocsEndpoint, organizationId: string) =>
  * @group Brands
  * @api POST /v2/organizations/:organizationId/brands Create brand
  * @apiBody string key A unique key for the brand (lowercase alphanumeric + hyphens)
- * @apiBody ILocaleData localeData? The locale and timezone codes, as provided by the client browser.
+ * @apiBody string timezone? Define the long-form timezone.
+ * @apiBody string locale? Define the locale code.
  * @apiSuccess IBrand . The newly created brand.
  */
 export const createBrand = (endpoint: VerdocsEndpoint, organizationId: string, params: ICreateBrandRequest) =>
@@ -45,6 +46,8 @@ export const getBrand = (endpoint: VerdocsEndpoint, organizationId: string, bran
  *
  * @group Brands
  * @api PATCH /v2/organizations/:organizationId/brands/:brandId Update brand
+ * @apiBody string timezone? Define the long-form timezone.
+ * @apiBody string locale? Define the locale code.
  * @apiSuccess IBrand . The updated brand.
  */
 export const updateBrand = (endpoint: VerdocsEndpoint, organizationId: string, brandId: string, params: IUpdateBrandRequest) =>

--- a/src/Organizations/Organizations.ts
+++ b/src/Organizations/Organizations.ts
@@ -16,7 +16,7 @@ import {IEntitlement, IOrganization, IProfile, TOrganizationUsage} from '../Mode
 import {VerdocsEndpoint} from '../VerdocsEndpoint';
 import {IAuthenticateResponse} from '../Users';
 import {collapseEntitlements} from '../Utils';
-import {ILocaleData, TUsageType} from '../BaseTypes';
+import {TUsageType} from '../BaseTypes';
 
 /**
  * Get an organization by ID. Note that this endpoint will return only a subset of fields
@@ -105,7 +105,8 @@ export const getOrganizationUsage = (
  * @apiBody string privacy_policy_url? URL of a Privacy Policy page, shown in bottom-right of signing experience. Hidden if not set.
  * @apiBody string powered_by_label? "Powered-by..." label, shown in bottom-left of signing experience. Hidden if not set.
  * @apiBody string powered_by_url? URL for the Powered By label to show when clicked. Rendered as a static label if not set.
- * @apiBody ILocaleData localeData? The locale and timezone codes, as provided by the client browser.
+ * @apiBody string timezone? Define the long-form timezone.
+ * @apiBody string locale? Define the locale code.
  * @apiBody string disclaimer? Custom disclaimer/disclosure block to present to envelope recipients. May contain basic HTML (e.g. ol/ul/li tags) but complex or dangerous (e.g. script) tags will be rejected.
  * @apiBody object data? Developer-supplied metadata attached to the organization.
  * @apiBody boolean deletion_protected? Prevents the organization from being deleted until turned off. Defaults to true.
@@ -113,7 +114,7 @@ export const getOrganizationUsage = (
  */
 export const createOrganization = (
   endpoint: VerdocsEndpoint,
-  params: {name: string; localeData?: ILocaleData} & Partial<
+  params: {name: string} & Partial<
     Pick<
       IOrganization,
       | 'parent_id'
@@ -130,6 +131,8 @@ export const createOrganization = (
       | 'disclaimer'
       | 'data'
       | 'deletion_protected'
+      | 'timezone'
+      | 'locale'
     >
   >,
 ) =>
@@ -162,6 +165,8 @@ export const createOrganization = (
  * @apiBody string disclaimer? Custom disclaimer/disclosure block to present to envelope recipients. May contain basic HTML (e.g. ol/ul/li tags) but complex or dangerous (e.g. script) tags will be rejected.
  * @apiBody object data? Developer-supplied metadata attached to the organization.
  * @apiBody boolean deletion_protected? Prevents the organization from being deleted until turned off.
+ * @apiBody string timezone? Define the long-form timezone.
+ * @apiBody string locale? Define the locale code.
  * @apiSuccess IOrganization . The details for the updated organization
  */
 export const updateOrganization = (endpoint: VerdocsEndpoint, organizationId: string, params: Partial<IOrganization>) =>

--- a/src/Organizations/Types.ts
+++ b/src/Organizations/Types.ts
@@ -1,4 +1,4 @@
-import {ILocaleData, TApiKeyPermission, TEventName, TNotificationType, type TWebhookAuthMethod, TWebhookEvent} from '../BaseTypes';
+import {TApiKeyPermission, TEventName, TNotificationType, type TWebhookAuthMethod, TWebhookEvent} from '../BaseTypes';
 import {TRole} from '../Sessions';
 
 export interface ICreateApiKeyRequest {
@@ -56,7 +56,8 @@ export interface ICreateBrandRequest {
   support_contact?: string;
   pdf_signature_reason?: string;
   pdf_signature_location?: string;
-  localeData?: ILocaleData;
+  timezone?: string | null;
+  locale?: string | null;
 }
 
 export interface IUpdateBrandRequest {
@@ -76,6 +77,8 @@ export interface IUpdateBrandRequest {
   support_contact?: string | null;
   pdf_signature_reason?: string | null;
   pdf_signature_location?: string | null;
+  timezone?: string | null;
+  locale?: string | null;
 }
 
 export interface IAddBrandEmailDomainRequest {

--- a/src/Users/Profiles.ts
+++ b/src/Users/Profiles.ts
@@ -73,6 +73,8 @@ export const switchProfile = (endpoint: VerdocsEndpoint, profileId: string) =>
  * @apiBody string phone? Phone number
  * @apiBody array(items:TPermission) permissions? New permissions to directly apply to the profile
  * @apiBody array(items:TRole) roles? New roles to assign to the profile
+ * @apiBody string timezone? Define the long-form timezone.
+ * @apiBody string locale? Define the locale code.
  * @apiSuccess IProfile . The updated profile
  */
 export const updateProfile = (endpoint: VerdocsEndpoint, profileId: string, params: IUpdateProfileRequest) =>
@@ -120,7 +122,7 @@ export const deleteProfile = (endpoint: VerdocsEndpoint, profileId: string) =>
  * import {createProfile} from '@verdocs/js-sdk';
  *
  * const newSession = await createProfile(VerdocsEndpoint.getDefault(), {
- *   orgName: 'NEW ORG', email: 'a@b.com', password: '12345678', firstName: 'FIRST', lastName: 'LAST', localeData: { locale: 'en-US', timezone: 'America/New_York' }
+ *   orgName: 'NEW ORG', email: 'a@b.com', password: '12345678', firstName: 'FIRST', lastName: 'LAST', locale: 'en-US', timezone: 'America/New_York'
  * });
  * ```
  */

--- a/src/Users/Types.ts
+++ b/src/Users/Types.ts
@@ -1,4 +1,4 @@
-import type {ILocaleData, TRequestStatus} from '../BaseTypes';
+import type {TRequestStatus} from '../BaseTypes';
 import {TPermission, TRole} from '../Sessions';
 
 export interface ICreateProfileRequest {
@@ -8,7 +8,8 @@ export interface ICreateProfileRequest {
   last_name: string;
   org_name: string;
   phone: string;
-  localeData?: ILocaleData;
+  timezone?: string | null;
+  locale?: string | null;
 }
 
 export interface IUpdateProfileRequest {
@@ -16,6 +17,8 @@ export interface IUpdateProfileRequest {
   last_name?: string;
   // email?: string;
   phone?: string;
+  timezone?: string | null;
+  locale?: string | null;
   permissions?: TPermission[];
   roles?: TRole[];
 }


### PR DESCRIPTION
## Description
* Instead of `localeData: {locale: 'en-US', timezone: 'America/New_York'}`, I flattened it to just be `{locale: 'en-US', timezone: 'America/New_York'}`. The `localeData` pattern was confusing because it didn't match the existing pattern.

## Example
```ts
// A little confusing
await updateBrand('brand_id', {name: '...', app_domain: '....', localeData: {locale: 'en-US', timezone: 'America/New_York'}})

// Matches expected pattern
await updateBrand('brand_id', {name: '...', app_domain: '....', locale: 'en-US', timezone: 'America/New_York'})
```