### PR TITLE
Switched docs to use the dev-docs repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "format": "prettier --write \"src/**/*.ts\"",
     "lint": "tslint -p tsconfig.json",
     "typecheck": "tsc --noEmit",
-    "docs": "typedoc && npm run generate-openapi && cp openapi.json ../developers.verdocs.com/public/openapi.json",
+    "docs": "typedoc && npm run generate-openapi && cp openapi.json ../dev-docs/app/openapi.json",
     "generate-openapi": "npx tsx openapi/generate-openapi.ts",
     "edit-openapi": "docker run -p 8081:80 -v $(pwd):/sdk -v $(pwd):/sdk swaggerapi/swagger-editor:next-v5",
     "view-openapi": "docker run -p 8081:80 -v $(pwd):/sdk swaggerapi/swagger-ui",


### PR DESCRIPTION
## Describe your changes
* I figured out why the dev-docs deploy didn't run into any issues, even though the `typedoc → openapi` translation isn't working.
      * The `docs` command in JS-SDK was still pointing to the old `developers.verdocs.com` repo (locally). I have the Dev Docs repo named `dev-docs` - we can change the name if we want, we'll just need to be on the same page.
      * When I ran `docs` and attempted `typedoc && npm run generate-openapi && cp openapi.json ../dev-docs/app/openapi.json`, I got the error that I was expecting to see. (I'll include a screenshot)
      * Although it looks like a lot, this original "[OpenAPI fix PR](https://github.com/Verdocs/js-sdk/pull/26)" is really just copying the original functions from `generate-openapi.ts` and putting them in their own files. My thought behind it was to make the logic a little more accessible.

<img width="1242" height="611" alt="image" src="https://github.com/user-attachments/assets/fc660d01-9d2e-430d-9ba4-d51995f60a47" />